### PR TITLE
Addition of Pause Screen

### DIFF
--- a/ecs.py
+++ b/ecs.py
@@ -18,6 +18,12 @@ class World:
         self.eindex[id] = entity
         return entity
 
+    # This function removes an entity from the ECS world, wiping it from all internal indexes
+    def remove_entity(self, entity):
+        self.eindex.pop(entity.id)
+        for component in entity.components:
+            self.cindex[component].remove(entity)
+
     # Query method which returns a list of all entities which have a given component. Useful for building systems
     def filter(self, component):
         entities = self.cindex.get(component)
@@ -192,7 +198,7 @@ WORLD = World()
 #
 class Entity(object):
     def __init__(self, id):
-        self.id = str(uuid.uuid4())
+        self.id = id
         self.components = []
 
     def attach(self, component: Component, namespace: str = None):

--- a/game_events.py
+++ b/game_events.py
@@ -4,4 +4,6 @@ SCENE_REFOCUS = pygame.event.custom_type()
 NEW_GAME = pygame.event.custom_type()
 CONTINUE = pygame.event.custom_type()
 OPTIONS = pygame.event.custom_type()
+PAUSE_CONTINUE = pygame.event.custom_type()
+PAUSE_QUIT_TO_MENU = pygame.event.custom_type()
 QUIT = pygame.QUIT

--- a/scene.py
+++ b/scene.py
@@ -9,21 +9,25 @@ import game_events
 class Scene:
     # This method get called once when the scene is first added to the game. This allows the Scene to do one time setup using resources stored in the world
     def setup(self, world):
-        print("You must override the setup() method!")
+        pass
 
     # Runs scene physics/logic/collision detection
     def update(self, events, world):
-        print("You must override the update() method!")
+        pass
 
     # Returns a scene switch event (see the helper functions in SceneManager to generate them)
     # This method should the scene
     def render(self, world):
-        print("You must override the render() method!")
+        pass
 
     # This method returns either True or False to allow the game to determine whether previous scenes should be rendered
     # This can be useful for like pause guis and the like
     def render_previous(self):
-        print("You must override the render_previous() method")
+        return False
+
+    # This method can be useful for cleaning up all the entities and systems your scene created from the game world
+    def teardown(self, world):
+        pass
 
 
 # Simple enum for switching between scenes
@@ -54,7 +58,7 @@ class SceneManager:
         if scene_switch["type"] == SceneSwitch.Nothing:
             pass
         elif scene_switch["type"] == SceneSwitch.Pop:
-            self.scenes.pop()
+            self.scenes.pop().teardown(world)
             pygame.event.post(pygame.event.Event(game_events.SCENE_REFOCUS))
         elif scene_switch["type"] == SceneSwitch.Push:
             scene = scene_switch["scene"]
@@ -63,14 +67,14 @@ class SceneManager:
         elif scene_switch["type"] == SceneSwitch.Replace:
             scene = scene_switch["scene"]
             scene.setup(world)
-            self.scenes.pop()
+            self.scenes.pop().teardown(world)
             self.scenes.append(scene)
         elif scene_switch["type"] == SceneSwitch.New_Root:
             scene = scene_switch["scene"]
             scene.setup(world)
             # Remove all scenes in reverse
             for _ in range(len(self.scenes)):
-                self.scenes.pop()
+                self.scenes.pop().teardown(world)
             self.scenes.append(scene)
 
     # Helper calls update for the current scene

--- a/scenes/game.py
+++ b/scenes/game.py
@@ -195,9 +195,9 @@ class GameScene(Scene):
         player_entity.attach(GravityComponent())
 
         # System registration
-        world.register_system(ForceSystem())
-        world.register_system(MovementSystem())
-        world.register_system(GlidingSystem())
+        self.systems = [ForceSystem(), MovementSystem(), GlidingSystem()]
+        for sys in self.systems:
+            world.register_system(sys)
 
     def update(self, events, world):
 
@@ -227,8 +227,11 @@ class GameScene(Scene):
         if keys[pygame.K_LEFT]:
             angle = player_entity.rotation.angle - 1
             player_entity.rotation.angle = max(angle, -90)
-        if keys[pygame.K_ESCAPE]:
-            return SceneManager.push(PauseScene())
+
+        for event in events:
+            # Use keyup here as a simple way to only trigger once and not repeatedly
+            if event.type == pygame.KEYUP and event.key == pygame.K_ESCAPE:
+                return SceneManager.push(PauseScene())
 
     def render(self, world):
         context = world.find_component("context")
@@ -274,3 +277,10 @@ class GameScene(Scene):
 
     def render_previous(self):
         return False
+
+    def teardown(self, world):
+        player = world.find_entity("player")
+        world.remove_entity(player)
+
+        for sys in self.systems:
+            world.unregister_system(sys)


### PR DESCRIPTION
There's a little bit of machinery here that needed to happen. I added a method to the ECS which allows one to remove entities from the world, and I added a new method on the Scene class - teardown(self, world) - which runs when your scene is removed from the game. You can do any cleanup you need to in that method.

I needed those in order to get Quit to Menu to work, since you could start a new game from the menu that was quit to. Suddenly, since the previous systems and player objects weren't cleaned up, there were two sans flying... sometimes. I couldn't figure that one out lol.

To halt the game, I do something really simple, just don't process the systems. This doesn't advance the game logic and the game freezes. Depending on what else we add we may need to add a paused field in the game context to allow systems to decide whether they should run themselves during paused state or not. This is more than enough for now