### PR TITLE
Very simplistic gravity, and require player to hit a button to begin the jump

### DIFF
--- a/scenes/game.py
+++ b/scenes/game.py
@@ -366,7 +366,6 @@ class GameScene(Scene):
             # The player only has direct control over their angle from the ground.
             # Our rudimentary physics takes care of the rest.
             # Also, clamp the angle from straight up to straight down.
-            # The player CAN rotate before jumping, which will affect initial glide conditions.
             if keys[pygame.K_RIGHT]:
                 angle = player_entity.rotation.angle + 1
                 player_entity.rotation.angle = min(angle, 90)


### PR DESCRIPTION
Gravity could be much better, and I may still tweak it because it has some issues. For example, set the initial jump to -45 or something, and the player will never actually descend. But it works decently well in very straightforward test cases.

Also, press space to start the jump/glide.