### PR TITLE
Physics upgrades

### DIFF
--- a/common_components.py
+++ b/common_components.py
@@ -33,6 +33,7 @@ class PlayerComponent(Component):
     def __init__(self):
         metadata = {
             "has_jumped": False,
+            "jumping": False,
             "currency": 0,
             "hasCloudSleeves": 0,
             "hasWings": 0,

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "cloudSleevesCost": 1000,
+    "cloudSleevesCost": 100,
     "height": 1280,
     "jetBootsCost": 9999,
     "save_file": "icarus.json",


### PR DESCRIPTION
Physics are more lenient - it's actually possible to _gain_ altitude without the jet booster upgrade!

Gravity and drag force are weaker above -2200 altitude, roughly where space begins in the background panels.

Starting angle is now -20 to match the jump angle. Along with this, there's now a small "animation" when you first jump - all it does is rotate counterclockwise until the player is level with the ground, and it can be interrupted by performing any action yourself (rotation or jet boost).