### PR TITLE
tweak some text

### DIFF
--- a/scenes/controls.py
+++ b/scenes/controls.py
@@ -21,7 +21,7 @@ class ControlsScene(Scene):
 
         rect = pygame.Rect(0, 0, 190, 49)
         rect.centerx = background.get_width() // 2
-        rect.centery = background.get_height() // 2 + 100
+        rect.centery = background.get_height() // 2 + 140
 
         button = world.gen_entity()
         button.attach(
@@ -43,7 +43,7 @@ class ControlsScene(Scene):
         context = world.find_component("context")
         screen = context["screen"]
 
-        surf = pygame.Surface((screen.get_width() // 2 - 30, 170))
+        surf = pygame.Surface((screen.get_width() // 2 - 30, 210))
         screen.blit(surf, (screen.get_width() // 4 + 15, screen.get_height() // 2 - 30))
 
         text = self.font.render(
@@ -51,10 +51,11 @@ class ControlsScene(Scene):
         )
         screen.blit(text, (screen.get_width() // 4 + 25, screen.get_height() // 2 - 20))
 
-        text = self.font.render(
-            "Press space to boost with the jet booster.", True, (245, 245, 245)
-        )
+        text = self.font.render("Don't crash into the ground.", True, (245, 245, 245))
         screen.blit(text, (screen.get_width() // 4 + 25, screen.get_height() // 2 + 20))
+
+        text = self.font.render("Shoot for the moon.", True, (245, 245, 245))
+        screen.blit(text, (screen.get_width() // 4 + 25, screen.get_height() // 2 + 60))
 
         # Display the buttons
         render_all_buttons(screen, world)

--- a/scenes/equip.py
+++ b/scenes/equip.py
@@ -319,7 +319,9 @@ class EquipScene(Scene):
         )
         screen.blit(text, (640, 714))
         text = self.small_font.render(
-            "Hold shift to turn like you didn't have wings.", True, (230, 200, 85)
+            "If you want to pretend you don't have wings, hold shift.",
+            True,
+            (230, 200, 85),
         )
         screen.blit(text, (640, 744))
 

--- a/scenes/menu.py
+++ b/scenes/menu.py
@@ -33,7 +33,7 @@ class MenuScene(Scene):
             path.join(user_data_dir(APP_NAME, APP_AUTHOR), settings["save_file"])
         ):
             men.append(("Continue", lambda: post(Event(CONTINUE))))
-        men.append(("Controls", lambda: post(Event(CONTROLS))))
+        men.append(("How to Play", lambda: post(Event(CONTROLS))))
         men.append(("Credits", lambda: post(Event(CREDITS))))
         men.append(("Quit", lambda: post(Event(QUIT))))
 


### PR DESCRIPTION
Just changes some of the text.

"Controls" button is now "How to Play".

Control/how-to-play scene removes a reference to the jet booster since you have to unlock it, and gives the general win and lose cons.

Upgrade screen wing description improved.