### PR TITLE
Window resize

### DIFF
--- a/scenes/credits.py
+++ b/scenes/credits.py
@@ -18,8 +18,8 @@ class CreditsScene(Scene):
         self.arcade_font = pygame.font.Font(
             find_data_file("resources/arcade-classic-font/ArcadeClassic-ov2x.ttf"), 26
         )
-        self.icarus_offset = 0
-        self.icarus_offset_increment = 1
+
+        self.scroll_offset = 0
 
     def setup(self, world):
         context = world.find_component("context")
@@ -27,7 +27,7 @@ class CreditsScene(Scene):
 
         rect = pygame.Rect(0, 0, 190, 49)
         rect.centerx = background.get_width() // 2
-        rect.centery = background.get_height() - 100
+        rect.centery = background.get_height() - 50
 
         button = world.gen_entity()
         button.attach(
@@ -42,6 +42,11 @@ class CreditsScene(Scene):
         for event in events:
             if event.type == BACK:
                 return SceneManager.pop()
+            if event.type == pygame.MOUSEBUTTONDOWN:
+                if event.button == 4 and self.scroll_offset < 0:
+                    self.scroll_offset += 5
+                if event.button == 5 and self.scroll_offset > -180:
+                    self.scroll_offset -= 5
 
         world.process_all_systems(events)
 
@@ -49,52 +54,73 @@ class CreditsScene(Scene):
         context = world.find_component("context")
         screen = context["screen"]
 
-        surf = pygame.Surface((screen.get_width() // 2 + 40, 630))
-        screen.blit(surf, (screen.get_width() // 4 - 20, 280))
+        surf = pygame.Surface(
+            (screen.get_width() // 2 + 40, screen.get_height() - 280 - 100)
+        )
 
         text = self.font.render("Programmed By:", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 4, 300))
+        surf.blit(text, (20, 20 + self.scroll_offset))
         text = self.font.render("Austin Decker", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 4, 340))
+        surf.blit(text, (20, 60 + self.scroll_offset))
         text = self.font.render("Dan Muckerman", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 4, 375))
+        surf.blit(text, (20, 95 + self.scroll_offset))
         text = self.font.render("Chris Yealy", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 4, 410))
+        surf.blit(text, (20, 130 + self.scroll_offset))
 
         text = self.font.render("Sprites By:", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 2 + 60, 300))
+        surf.blit(text, (surf.get_width() // 2 + 60, 20 + self.scroll_offset))
         text = self.font.render("Austin Forry", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 2 + 60, 340))
+        surf.blit(text, (surf.get_width() // 2 + 60, 60 + self.scroll_offset))
 
         prod = pygame.sprite.Sprite()
         prod.image = self.font.render(
-            "A Technical Incompetence Production", 1, (240, 240, 240)
+            "A Technical Incompetence Production", True, (240, 240, 240)
         )
-        prod.rect = prod.image.get_rect(centerx=screen.get_width() // 2, centery=470)
-        screen.blit(prod.image, prod.rect)
+        prod.rect = prod.image.get_rect(
+            centerx=surf.get_width() // 2, centery=190 + self.scroll_offset
+        )
+        surf.blit(prod.image, prod.rect)
 
         text = self.font.render("Sound fx and buttons:", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 4, 570))
+        surf.blit(text, (20, 290 + self.scroll_offset))
         text = self.font.render("kenney.nl", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 4, 610))
+        surf.blit(text, (20, 330 + self.scroll_offset))
 
         text = self.font.render("Music:", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 2 + 60, 570))
+        surf.blit(text, (surf.get_width() // 2 + 60, 290 + self.scroll_offset))
         text = self.font.render("freepd.com", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 2 + 60, 610))
+        surf.blit(text, (surf.get_width() // 2 + 60, 330 + self.scroll_offset))
 
         text = self.font.render("Fonts Used:", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 4, 660))
+        surf.blit(text, (20, 380 + self.scroll_offset))
         text = self.atari_font.render(
             "Atari Font by Genshichi Yasui", True, (245, 245, 245)
         )
-        screen.blit(text, (screen.get_width() // 4, 700))
+        surf.blit(text, (20, 420 + self.scroll_offset))
         text = self.arcade_font.render(
             "Arcade Classic Font by Koen Hachmang", True, (245, 245, 245)
         )
-        screen.blit(text, (screen.get_width() // 4, 725))
+        surf.blit(text, (20, 445 + self.scroll_offset))
         text = self.font.render("DpComic Font by codeman38", True, (245, 245, 245))
-        screen.blit(text, (screen.get_width() // 4, 748))
+        surf.blit(text, (20, 468 + self.scroll_offset))
+
+        # Arrows to indicate scrolling is available
+        if self.scroll_offset < 0:
+            up_triangle = (
+                (surf.get_width() - 35, 30),  # bottom left
+                (surf.get_width() - 15, 30),  # bottom right
+                (surf.get_width() - 25, 15),  # top
+            )
+            pygame.draw.polygon(surf, (245, 245, 245), up_triangle)
+        if self.scroll_offset > -180:
+            down_triangle = (
+                (surf.get_width() - 35, surf.get_height() - 30),  # top left
+                (surf.get_width() - 15, surf.get_height() - 30),  # top right
+                (surf.get_width() - 25, surf.get_height() - 15),  # bottom
+            )
+            pygame.draw.polygon(surf, (245, 245, 245), down_triangle)
+
+        screen.blit(surf, (screen.get_width() // 4 - 20, 280))
 
         # Display the buttons
         render_all_buttons(screen, world)

--- a/scenes/equip.py
+++ b/scenes/equip.py
@@ -20,6 +20,8 @@ from scene import Scene, SceneManager
 from utils import APP_AUTHOR, APP_NAME, find_data_file
 
 
+# TODO: Anywhere in here you see 200 subtracted from a y-value, that's because we don't support dynamic screen sizing.
+# TODO: Once we do, all that will have to change. This is just a quick and dirty fix for now.
 class EquipScene(Scene):
     def __init__(self):
         self.font = pygame.font.Font(
@@ -70,7 +72,7 @@ class EquipScene(Scene):
                 )
             )
 
-        rect = pygame.Rect(120, 560, 49, 49)
+        rect = pygame.Rect(120, 560 - 200, 49, 49)
         jet_boots_button = world.gen_entity()
         jet_boots_button.attach(
             ButtonComponent(
@@ -88,7 +90,7 @@ class EquipScene(Scene):
             )
         )
 
-        rect = pygame.Rect(120, 660, 49, 49)
+        rect = pygame.Rect(120, 660 - 200, 49, 49)
         more_fuel_button = world.gen_entity()
         more_fuel_button.attach(
             ButtonComponent(
@@ -112,7 +114,7 @@ class EquipScene(Scene):
             )
         )
 
-        rect = pygame.Rect(640, 560, 49, 49)
+        rect = pygame.Rect(640, 560 - 200, 49, 49)
         cloud_sleeves_button = world.gen_entity()
         cloud_sleeves_button.attach(
             ButtonComponent(
@@ -130,7 +132,7 @@ class EquipScene(Scene):
             )
         )
 
-        rect = pygame.Rect(640, 660, 49, 49)
+        rect = pygame.Rect(640, 660 - 200, 49, 49)
         wings_button = world.gen_entity()
         wings_button.attach(
             ButtonComponent(
@@ -230,11 +232,13 @@ class EquipScene(Scene):
         screen.blit(text, (50, 50))
 
         text = self.big_font.render("Legs:", True, (245, 245, 245))
-        screen.blit(text, (120, 480))
-        pygame.draw.line(screen, (245, 245, 245), (120, 531), (223, 531), width=8)
+        screen.blit(text, (120, 480 - 200))
+        pygame.draw.line(
+            screen, (245, 245, 245), (120, 531 - 200), (223, 531 - 200), width=8
+        )
 
         text = self.font.render("Jet Booster", True, (245, 245, 245))
-        screen.blit(text, (180, 550))
+        screen.blit(text, (180, 550 - 200))
         if player_entity.player.hasJetBoots == 1:
             text = self.font.render("Owned", True, (245, 245, 245))
         else:
@@ -246,14 +250,14 @@ class EquipScene(Scene):
             text = self.font.render(
                 f"Cost: ${settings['jetBootsCost']}", True, text_color
             )
-        screen.blit(text, (180, 582))
+        screen.blit(text, (180, 582 - 200))
         text = self.small_font.render(
             "Press space to give yourself a boost!", True, (230, 200, 85)
         )
-        screen.blit(text, (120, 614))
+        screen.blit(text, (120, 614 - 200))
 
         text = self.font.render("More Fuel", True, (245, 245, 245))
-        screen.blit(text, (180, 650))
+        screen.blit(text, (180, 650 - 200))
         if player_entity.player.extraFuel == 9:
             text = self.font.render("Maxed Out", True, (245, 245, 245))
         else:
@@ -263,26 +267,27 @@ class EquipScene(Scene):
                 else (170, 200, 200)
             )
             text = self.font.render(f"Cost: ${self.extra_fuel_cost}", True, text_color)
-        screen.blit(text, (180, 682))
-        # TODO
+        screen.blit(text, (180, 682 - 200))
         text = self.small_font.render(
             "More fuel means more boosting!", True, (230, 200, 85)
         )
-        screen.blit(text, (120, 714))
+        screen.blit(text, (120, 714 - 200))
         if player_entity.player.hasJetBoots > 0:
             text = self.small_font.render(
                 f"Total boosts: {player_entity.player.extraFuel + 1}{'! Wow!' if player_entity.player.extraFuel == 9 else ''}",
                 True,
                 (220, 40, 10),
             )
-            screen.blit(text, (120, 744))
+            screen.blit(text, (120, 744 - 200))
 
         text = self.big_font.render("Arms:", True, (245, 245, 245))
-        screen.blit(text, (640, 480))
-        pygame.draw.line(screen, (245, 245, 245), (640, 531), (763, 531), width=8)
+        screen.blit(text, (640, 480 - 200))
+        pygame.draw.line(
+            screen, (245, 245, 245), (640, 531 - 200), (763, 531 - 200), width=8
+        )
 
         text = self.font.render("Cloud Sleeves", True, (245, 245, 245))
-        screen.blit(text, (700, 550))
+        screen.blit(text, (700, 550 - 200))
         if player_entity.player.hasCloudSleeves == 1:
             text = self.font.render("Owned", True, (245, 245, 245))
         else:
@@ -294,14 +299,14 @@ class EquipScene(Scene):
             text = self.font.render(
                 f"Cost: ${settings['cloudSleevesCost']}", True, text_color
             )
-        screen.blit(text, (700, 582))
+        screen.blit(text, (700, 582 - 200))
         text = self.small_font.render(
             "Don't let gravity get you down!", True, (230, 200, 85)
         )
-        screen.blit(text, (640, 614))
+        screen.blit(text, (640, 614 - 200))
 
         text = self.font.render("Bird Wings", True, (245, 245, 245))
-        screen.blit(text, (700, 650))
+        screen.blit(text, (700, 650 - 200))
         if player_entity.player.hasWings == 1:
             text = self.font.render("Owned", True, (245, 245, 245))
         else:
@@ -311,19 +316,19 @@ class EquipScene(Scene):
                 else (170, 200, 200)
             )
             text = self.font.render(f"Cost: ${settings['wingsCost']}", True, text_color)
-        screen.blit(text, (700, 682))
+        screen.blit(text, (700, 682 - 200))
         text = self.small_font.render(
             "Make tighter turns! Y'know, like a bird. Just go with it.",
             True,
             (230, 200, 85),
         )
-        screen.blit(text, (640, 714))
+        screen.blit(text, (640, 714 - 200))
         text = self.small_font.render(
             "If you want to pretend you don't have wings, hold shift.",
             True,
             (230, 200, 85),
         )
-        screen.blit(text, (640, 744))
+        screen.blit(text, (640, 744 - 200))
 
         # Icarus himself
         sprite = pygame.sprite.Sprite()
@@ -331,7 +336,7 @@ class EquipScene(Scene):
         sprite.image = pygame.transform.scale(sprite.image, (288, 200))
         sprite.rect = sprite.image.get_rect()
         sprite.rect.centerx = screen.get_width() // 2
-        sprite.rect.centery = screen.get_height() // 2 - 240 + self.icarus_offset
+        sprite.rect.centery = screen.get_height() // 2 - 200 + self.icarus_offset
         screen.blit(sprite.image, sprite.rect)
 
         # Display the buttons

--- a/scenes/game.py
+++ b/scenes/game.py
@@ -444,15 +444,19 @@ class CameraSystem(System):
 
         if camera.x < 0:
             camera.x = 0
-        if camera.y > 0:
-            camera.y = 0
+
+        # TODO: must come up with a better way to handle this than hardcoding 192, to allow screen resizing
+        if camera.y > 192:
+            camera.y = 192
+
         if camera.y < -2540:
             camera.y = -2540
 
 
 def calculate_altitude(player, screen):
     sprite_height = player.graphic.sprite.image.get_height()
-    return player.position.y - screen.get_height() + sprite_height
+    # TODO: must come up with a better way to handle this than hardcoding 960, to allow screen resizing
+    return player.position.y - 960 + sprite_height
 
 
 def load(world):
@@ -531,7 +535,7 @@ class GameScene(Scene):
         player_entity.attach(
             GraphicComponent(PlayerSprite("resources/icarus_body.png"))
         )
-        player_entity.attach(PositionComponent(100, 100))
+        player_entity.attach(PositionComponent(160, 486))
         player_entity.attach(PhysicsComponent())
         player_entity.attach(RotationComponent(-20))
         player_entity.attach(PlayerComponent())

--- a/scenes/title.py
+++ b/scenes/title.py
@@ -103,7 +103,7 @@ class TitleScene(Scene):
         sprite.image = pygame.image.load(find_data_file("resources/icarus_body.png"))
         sprite.rect = sprite.image.get_rect()
         sprite.rect.centerx = 180
-        sprite.rect.centery = screen.get_height() // 2 + 70 + (self.icarus_offset // 3)
+        sprite.rect.centery = screen.get_height() // 2 + 190 + (self.icarus_offset // 3)
         screen.blit(sprite.image, sprite.rect)
 
         # Moon's hot

--- a/scenes/victory.py
+++ b/scenes/victory.py
@@ -30,7 +30,7 @@ class VictoryScene(Scene):
         victory_text = pygame.sprite.Sprite()
         victory_text.image = self.victory_font.render("VICTORY", True, (240, 240, 240))
         victory_text.rect = victory_text.image.get_rect(
-            centerx=background.get_width() // 2, centery=160
+            centerx=background.get_width() // 2, centery=110
         )
 
         self.victory_screen.add(victory_text)
@@ -42,7 +42,7 @@ class VictoryScene(Scene):
             (185, 185, 185),
         )
         sub_text.rect = sub_text.image.get_rect(
-            centerx=background.get_width() // 2, centery=250
+            centerx=background.get_width() // 2, centery=190
         )
 
         self.victory_screen.add(sub_text)
@@ -100,7 +100,7 @@ class VictoryScene(Scene):
         )
         moon_sprite.rect = moon_sprite.image.get_rect()
         moon_sprite.rect.centerx = screen.get_width() / 2
-        moon_sprite.rect.centery = screen.get_height() / 2
+        moon_sprite.rect.centery = screen.get_height() / 2 + 30
         screen.blit(moon_sprite.image, moon_sprite.rect)
 
         # Sub text backing box
@@ -109,7 +109,7 @@ class VictoryScene(Scene):
             (10, 10, 10),
             [
                 screen.get_width() // 2 - 300,
-                250 - 15 - 10,  # text y position - half font height - buffer
+                190 - 15 - 10,  # text y position - half font height - buffer
                 600,
                 50,
             ],

--- a/settings.json
+++ b/settings.json
@@ -2,7 +2,7 @@
   "metadata": {
     "cloudSleevesCost": 100,
     "extraFuelCost": 5000,
-    "height": 1366,
+    "height": 1280,
     "jetBootsCost": 3500,
     "save_file": "icarus.json",
     "subtitle": "Shoot for the Moon",

--- a/settings.json
+++ b/settings.json
@@ -2,12 +2,12 @@
   "metadata": {
     "cloudSleevesCost": 100,
     "extraFuelCost": 5000,
-    "height": 1280,
+    "height": 1366,
     "jetBootsCost": 3500,
     "save_file": "icarus.json",
     "subtitle": "Shoot for the Moon",
     "title": "Icarus",
-    "width": 960,
+    "width": 720,
     "wingsCost": 2000
   },
   "metatype": "settings"


### PR DESCRIPTION
Screen resolution changed to 1366x720. Hopefully just a temporary stopgap to support smaller screen sizes until we can implement proper dynamic resizing.

All the changes are pretty straightforward coordinate updates, shifting things up or down on the screen. The only part that's more complicated is the credits screen - rather than try to rearrange the credits to fit the screen, now all the text just blits to the black surface and it's scrollable with the mouse wheel (trackpad scrolling also works).

One thing to notice - the altitude where you crash is now slightly lower than the actual bottom of the screen. At first this was an accident, but as I tested it I kind of liked it. Removes the slightly awkward moment where you're on the crash results screen and Icarus is just kind of floating at an angle just above the bottom edge. And it gives the player a bit more leniency if they're about to crash but might be able to pull up in time. Let me know if you hate it, I'm fine pushing another commit to fix that. The fix is pretty easy too.